### PR TITLE
Potential fix

### DIFF
--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -61,7 +61,9 @@ router.post('/login', async (req, res) => {
       return res.status(200).json({
         jwt: localJwt
       });
-    }    
+    } else {
+      return res.status(verifiedProof.status);
+    }
   }catch(err) {
     console.log(err);
     res.status(400).send(err);


### PR DESCRIPTION
Hey @AparnaJoshi007!

Apologies for the delay in circling back with you on the hang you were seeing in the `/login` handler!

After running a few tests to see if I could reproduce it in a different context, I took a look through the handler and recognized what may be happening is that when `verifiedProof.status === 400`, the final `if` statement is skipped over, but it also doesn't (hopefully!) throw an exception, so we don't hit the `catch` block either—maybe?

https://github.com/AparnaJoshi007/nodejs-nuid/blob/79380da3728332ed015cce48e2d97df6a9b90e74/src/routes/auth.js#L57-L68

I haven't been able to test this tiny PR quite yet, it's really meant as just a sketch—it seemed like the easiest/most visual way to communicate. So feel free to totally crunch it. And I apologize if I've missed something, which is very often the case.

In any case, looking forward to seeing how it all turns out!